### PR TITLE
Build on Ubuntu 17.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /usr/local
 INSTALL = install
-MANPAGE_XSL = /usr/share/xml/docbook/stylesheet/nwalsh/current/manpages/docbook.xsl
+MANPAGE_XSL = /usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
 
 BINDIR = $(PREFIX)/bin
 MANDIR = $(PREFIX)/share/man

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 This is an experimental development branch.  Please use the
 [v1.0 branch](https://github.com/schani/metapixel/tree/v1.0).
+
+## Related Projects
+
+- [collage](https://github.com/ThinkR-open/collage) (implemented in R)


### PR DESCRIPTION
Hi,

I had problems with `metapixel-prepare` from the Ubuntu repository. I also had some minor issues building from this source repository. Minor changes (here) have got that working. Have tested the resulting binary and it works fine!

Best regards,
Andrew.